### PR TITLE
add button to download workflow tutorial as pdf

### DIFF
--- a/app/workflows/anonymize_case_data/workflow.py
+++ b/app/workflows/anonymize_case_data/workflow.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2024 Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project.
 #
-import math
 import os
-from collections import defaultdict
-from json import dumps, loads
 
 import plotly.io as pio
 import streamlit as st
@@ -13,8 +10,8 @@ import app.util.example_outputs_ui as example_outputs_ui
 import app.util.ui_components as ui_components
 import app.workflows.anonymize_case_data.config as config
 import app.workflows.anonymize_case_data.variables as ds_variables
-import toolkit.anonymize_case_data.queries as queries
 import toolkit.anonymize_case_data.visuals as visuals
+from app.util.download_pdf import add_download_pdf
 from toolkit.anonymize_case_data import AnonymizeCaseData, color_schemes
 
 
@@ -37,7 +34,13 @@ def create(sv: ds_variables.SessionVariables, workflow: None):
     df = None
     acd: AnonymizeCaseData = sv.workflow_object.value
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with prepare_tab:
         uploader_col, model_col = st.columns([2, 1])
         with uploader_col:

--- a/app/workflows/compare_case_groups/workflow.py
+++ b/app/workflows/compare_case_groups/workflow.py
@@ -9,6 +9,7 @@ import streamlit as st
 import app.util.example_outputs_ui as example_outputs_ui
 import app.workflows.compare_case_groups.variables as gn_variables
 from app.util import ui_components
+from app.util.download_pdf import add_download_pdf
 from toolkit.compare_case_groups import prompts
 from toolkit.compare_case_groups.build_dataframes import (
     build_attribute_df,
@@ -43,7 +44,13 @@ def create(sv: gn_variables.SessionVariables, workflow=None):
     )
 
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with prepare_tab:
         uploader_col, model_col = st.columns([1, 1])
         with uploader_col:

--- a/app/workflows/detect_case_patterns/workflow.py
+++ b/app/workflows/detect_case_patterns/workflow.py
@@ -20,6 +20,7 @@ from st_aggrid import (
 import app.util.example_outputs_ui as example_outputs_ui
 import app.workflows.detect_case_patterns.variables as ap_variables
 from app.util import ui_components
+from app.util.download_pdf import add_download_pdf
 from toolkit.AI.classes import LLMCallback
 from toolkit.detect_case_patterns import prompts
 from toolkit.detect_case_patterns.config import (
@@ -64,7 +65,13 @@ def create(sv: ap_variables.SessionVariables, workflow):
     selected_pattern = ""
     graph_df = None
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with uploader_tab:
         uploader_col, model_col = st.columns([2, 1])
         with uploader_col:
@@ -245,6 +252,11 @@ def create(sv: ap_variables.SessionVariables, workflow):
                 gridoptions = gb.build()
                 gridoptions["columnDefs"][0]["minWidth"] = 100
                 gridoptions["columnDefs"][1]["minWidth"] = 400
+
+                st.warning(
+                    "Select column headers to rank patterns by that attribute. Use quickfilter or column filters to narrow down the list of patterns. Select a pattern to continue."
+                )
+
                 response = AgGrid(
                     show_df,
                     key=f"report_grid_{sv.detect_case_patterns_table_index.value}",
@@ -308,9 +320,7 @@ def create(sv: ap_variables.SessionVariables, workflow):
                                     height=220, width=600)
                     )
                     st.altair_chart(count_ct, use_container_width=True)                       
-                    st.warning(
-                        "Select column headers to rank patterns by that attribute. Use quickfilter or column filters to narrow down the list of patterns. Select a pattern to continue."
-                    )
+
             elif sv.detect_case_patterns_table_index.value > 0:
                 st.info("No patterns detected.")
     with explain_tab:

--- a/app/workflows/detect_entity_networks/workflow.py
+++ b/app/workflows/detect_entity_networks/workflow.py
@@ -8,6 +8,7 @@ import os
 import pandas as pd
 import polars as pl
 import streamlit as st
+from app.util.download_pdf import add_download_pdf
 import workflows.detect_entity_networks.functions as functions
 import workflows.detect_entity_networks.variables as rn_variables
 import app.util.example_outputs_ui as example_outputs_ui
@@ -65,7 +66,13 @@ async def create(sv: rn_variables.SessionVariables, workflow=None):
     )
     selected_df = None
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with uploader_tab:
         uploader_col, model_col = st.columns([3, 2])
         with uploader_col:

--- a/app/workflows/extract_record_data/workflow.py
+++ b/app/workflows/extract_record_data/workflow.py
@@ -9,6 +9,7 @@ import app.util.schema_ui as schema_ui
 import app.util.ui_components as ui_components
 import app.workflows.extract_record_data.variables as variables
 import toolkit.extract_record_data.data_extractor as data_extractor
+from app.util.download_pdf import add_download_pdf
 from app.util.openai_wrapper import UIOpenAIConfiguration
 
 ai_configuration = UIOpenAIConfiguration().get_configuration()
@@ -24,7 +25,13 @@ async def create(sv: variables.SessionVariables, workflow: None):
 
     intro_tab, schema_tab, generator_tab, mock_tab = st.tabs(['Extract Record Data workflow:', 'Prepare data schema', 'Extract structured records', 'View example outputs'])
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with schema_tab:
         sv.loaded_schema_filename.value = schema_ui.build_schema_ui(
             sv.schema.value, sv.loaded_schema_filename.value)

--- a/app/workflows/generate_mock_data/workflow.py
+++ b/app/workflows/generate_mock_data/workflow.py
@@ -10,6 +10,7 @@ import app.util.ui_components as ui_components
 import app.workflows.generate_mock_data.variables as bds_variables
 import toolkit.generate_mock_data.data_generator as data_generator
 import toolkit.generate_mock_data.text_generator as text_generator
+from app.util.download_pdf import add_download_pdf
 from app.util.openai_wrapper import UIOpenAIConfiguration
 
 ai_configuration = UIOpenAIConfiguration().get_configuration()
@@ -25,7 +26,13 @@ async def create(sv: bds_variables.SessionVariables, workflow: None):
 
     intro_tab, schema_tab, record_generator_tab, text_generator_tab, mock_tab = st.tabs(['Generate Mock Data workflow:', 'Prepare data schema', 'Generate mock records', 'Generate mock texts', 'View example outputs'])
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with schema_tab:
         sv.loaded_filename.value = schema_ui.build_schema_ui(sv.schema.value, sv.loaded_filename.value)
     with record_generator_tab:

--- a/app/workflows/match_entity_records/workflow.py
+++ b/app/workflows/match_entity_records/workflow.py
@@ -54,7 +54,13 @@ async def create(sv: rm_variables.SessionVariable, workflow=None) -> None:
     )
     selected_df = None
     with intro_tab:
-        st.markdown(get_intro())
+        file_content = get_intro()
+        st.markdown(file_content)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with uploader_tab:
         uploader_col, model_col = st.columns([2, 1])
         with uploader_col:

--- a/app/workflows/query_text_data/workflow.py
+++ b/app/workflows/query_text_data/workflow.py
@@ -63,7 +63,13 @@ async def create(sv: SessionVariables, workflow=None):
     if f"{workflow}_uploader_index" not in st.session_state:
         st.session_state[f"{workflow}_uploader_index"] = str(random.randint(0, 100))
     with intro_tab:
-        st.markdown(get_intro(), unsafe_allow_html=True)
+        file_content = get_intro()
+        st.markdown(file_content, unsafe_allow_html=True)
+        add_download_pdf(
+            f"{workflow}_introduction_tutorial.pdf",
+            file_content,
+            ":floppy_disk: Download as PDF",
+        )
     with uploader_tab:
         st.markdown("##### Upload data for processing")
         files = st.file_uploader(


### PR DESCRIPTION
This pull request focuses on improving the user experience by adding a feature to download introductory tutorials as PDFs across multiple workflows and making minor code cleanups. The most important changes include importing the `add_download_pdf` function and updating the `create` methods to use this function.