### PR TITLE
fix erd csv load update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed torch dependency version constraints in pyproject.toml
 - Fixed plotly installation in dependencies
 - Fixed detect entity networks prepare_model edge case handling
+- Fixed CSV file upload persistence in Extract Record Data workflow: uploaded CSV files and dataframes now persist when navigating between tabs by caching files and dataframes in session state and preserving the extraction mode selection
 - Fixed Detect Case Patterns to gracefully handle cases with no converging patterns, returning empty DataFrame instead of single NaN row
 - Added comprehensive unit tests for empty pattern detection scenario
 - Fixed Detect Case Patterns `compute_attribute_counts()` to handle missing columns gracefully with warning message

--- a/app/workflows/extract_record_data/workflow.py
+++ b/app/workflows/extract_record_data/workflow.py
@@ -44,7 +44,24 @@ async def create(sv: variables.SessionVariables, workflow: None):
                 st.warning("Prepare data schema to continue.")
             else:
                 st.markdown("##### Record extraction controls")
-                mode = st.radio("Mode", ["Extract from single text", "Extract from rows of CSV file"], horizontal=True)
+                if f"{workflow}_extraction_mode" not in st.session_state:
+                    st.session_state[f"{workflow}_extraction_mode"] = 0  # 0 = single text, 1 = CSV
+                
+                mode_index = st.radio(
+                    "Mode", 
+                    ["Extract from single text", "Extract from rows of CSV file"], 
+                    horizontal=True,
+                    index=st.session_state[f"{workflow}_extraction_mode"],
+                    key=f"{workflow}_extraction_mode_radio"
+                )
+                
+                mode_index_map = {"Extract from single text": 0, "Extract from rows of CSV file": 1}
+                reverse_map = {0: "Extract from single text", 1: "Extract from rows of CSV file"}
+                if st.session_state[f"{workflow}_extraction_mode"] != mode_index_map[mode_index]:
+                    st.session_state[f"{workflow}_extraction_mode"] = mode_index_map[mode_index]
+                    st.rerun()
+                mode = mode_index
+                
                 input_texts = []
                 if mode == "Extract from single text":
                     st.text_area("Unstructured text input", key=sv.text_input.key, height=400)


### PR DESCRIPTION
This pull request improves the CSV file upload experience in the Extract Record Data workflow by ensuring that uploaded files and their data persist when navigating between tabs or changing extraction modes. The changes add session-based caching for files and dataframes, synchronize the extraction mode selection with session state, and update UI logic to use cached data. This resolves previous issues where uploaded CSVs would be lost or reloaded unnecessarily.

**CSV File Upload Persistence and Caching**
* Added session state caching for uploaded CSV files and parsed dataframes in `multi_csv_uploader` to ensure files and data persist across tab changes and mode switches.
* Updated logic to use cached files/dataframes when reloading or selecting files, reducing unnecessary reads and improving reliability. [[1]](diffhunk://#diff-d92e8c851bfcb96cceb849a17ccb7c8949e6b6bfb749482321339f6c066d3e0fL293-R352) [[2]](diffhunk://#diff-d92e8c851bfcb96cceb849a17ccb7c8949e6b6bfb749482321339f6c066d3e0fL335-R375)

**Extraction Mode Synchronization**
* Extraction mode selection in the Extract Record Data workflow is now stored in session state and synchronized with the UI, so switching modes preserves user choice and triggers a rerun only when needed.

**Bug Fixes**
* Fixed CSV file upload persistence in the Extract Record Data workflow by caching files and dataframes in session state and preserving extraction mode selection.