### PR TITLE
typo fixes and instructions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Detect Case Patterns `detect_patterns()` normalization to handle empty pattern DataFrames without division errors
 - Fixed CSV error in detect entity networks report functionality
 - Fixed entity network exploration to properly handle DataFrame-based trimmed attributes
+- Fix typo on anonymize case data
+- Fix macos instructions to install package
 
 ## [0.1.2] - 2024-10-15
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,7 +10,12 @@
 
     - Linux:  `sudo apt-get install wkhtmltopdf`
 
-    - MacOS: `brew install homebrew/cask/wkhtmltopdf`
+  - macOS: 
+  ``` 
+  curl -L https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg -O
+
+  installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target ~
+  ```
 
 
 ## Running the app

--- a/README.md
+++ b/README.md
@@ -232,7 +232,12 @@ For developers who want to contribute to Intelligence Toolkit or run it from sou
 - wkhtmltopdf (for PDF report generation)
   - Windows: [Download installer](https://wkhtmltopdf.org/downloads.html)
   - Linux: `sudo apt-get install wkhtmltopdf`
-  - macOS: `brew install homebrew/cask/wkhtmltopdf`
+  - macOS: 
+  ``` 
+  curl -L https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg -O
+
+  installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target ~
+  ```
 
 **Setup Instructions:**
 1. Clone the repository:

--- a/app/workflows/anonymize_case_data/workflow.py
+++ b/app/workflows/anonymize_case_data/workflow.py
@@ -292,7 +292,7 @@ def create(sv: ds_variables.SessionVariables, workflow: None):
             att_separator = ";"
             data_schema = acd.get_data_schema()
             with c1:
-                st.markdown("##### Constuct query")
+                st.markdown("##### Construct query")
                 if len(sdf) > 0:
                     count_holder = st.empty()
 


### PR DESCRIPTION
This pull request addresses minor bug fixes and documentation improvements, focusing on correcting instructions for installing `wkhtmltopdf` on macOS and fixing a typo in the user interface. The most important changes are grouped below:

Documentation updates:

* Updated macOS installation instructions for `wkhtmltopdf` in both `DEVELOPING.md` and `README.md` to use the official package installer instead of Homebrew, ensuring more reliable setup for PDF report generation. [[1]](diffhunk://#diff-8822179a8da757fde968cf80a9162e1c1d6f8cc170509cfbdea10be03b7e7d20L13-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R240)

Bug fixes and UI improvements:

* Fixed a typo in the "Construct query" section header in the `app/workflows/anonymize_case_data/workflow.py` workflow UI.
* Added a changelog entry for the typo fix and updated macOS installation instructions.